### PR TITLE
ENG-891: Fixes to naming of packages

### DIFF
--- a/patchelf.spec
+++ b/patchelf.spec
@@ -2,7 +2,7 @@ Summary: A utility for patching ELF binaries
 
 Name: patchelf
 Version: @PACKAGE_VERSION@
-Release: @RPM_RELEASE@
+Release: @RPM_RELEASE@%{?dist}
 Epoch: 1
 License: GPL
 Group: Development/Tools

--- a/patchelf_builder.sh
+++ b/patchelf_builder.sh
@@ -446,7 +446,7 @@ build_deb(){
     dpkg-source -x $DSC
     cd $DIRNAME
     sed -i "s: serial-tests::g" configure.ac
-    dch -m -D "$OS_NAME" --force-distribution -v "$VERSION-$DEB_RELEASE.$OS_NAME" 'Update distribution'
+    dch -m -D "$OS_NAME" --force-distribution -v "1:$VERSION-$DEB_RELEASE.$OS_NAME" 'Update distribution'
     dpkg-buildpackage -rfakeroot -uc -us -b
 
     cd ${WORKDIR}


### PR DESCRIPTION
```
dpkg-source: info: using options from patchelf-0.11/debian/source/options: --extend-diff-ignore=bootstrap.sh --extend-diff-ignore=release.nix --extend-diff-ignore=version --extend-diff-ignore=BUGS
dpkg-buildpackage: info: binary-only upload (no source included)
root@debian-10:/mnt# ls
deb  patchelf.properties  patchelf_builder.sh  source_deb  source_tarball  test
root@debian-10:/mnt# ls deb/
patchelf-dbgsym_0.11-1.buster_amd64.deb  patchelf_0.11-1.buster_amd64.deb
```


```
[root@centos-6 mnt]# ls rpm
patchelf-0.11-1.el6.x86_64.rpm  patchelf-debuginfo-0.11-1.el6.x86_64.rpm
```